### PR TITLE
Add a number after app name to indicate duplicates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl AudioController {
             let mut name = str_filename;
             let mut counter = 2;
             while self.sessions.iter().any(|i| i.getName() == name) {
-                name = format!("{}{}", name, counter);
+                name = format!("{}({})", name, counter);
                 counter += 1;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,16 @@ impl AudioController {
                     continue;
                 }
             };
-            let application_session = ApplicationSession::new(audio_control, str_filename);
+            //loop through all sessions and check if the session name already exists, if it does, change name to name + 1
+            let mut name = str_filename;
+            let mut counter = 2;
+            while self.sessions.iter().any(|i| i.getName() == name) {
+                name = format!("{}{}", name, counter);
+                counter += 1;
+            }
+
+            let application_session = ApplicationSession::new(audio_control, name);
+
             self.sessions.push(Box::new(application_session));
         }
     }


### PR DESCRIPTION
If an app name already exists, it will add a number behind it, which will be increased for each duplicate.