### PR TITLE
Return all sessions with same name

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -9,7 +9,11 @@ fn main() {
         controller.GetDefaultAudioEnpointVolumeControl();
         controller.GetAllProcessSessions();
         let test = controller.get_all_session_names();
-        let master_session = controller.get_session_by_name("master".to_string());
-        println!("{:?}",master_session.unwrap().getVolume());
+        let master_session = controller.get_sessions_by_name("master".to_string());
+        if let Some(session) = master_session.first() {
+            println!("{:?}", session.getVolume());
+        } else {
+            println!("No master session found");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,13 +237,19 @@ impl AudioController {
 
     }
 
-
+    //returns all session names
     pub unsafe fn get_all_session_names(&self) -> Vec<String> {
         self.sessions.iter().map(|i| i.getName()).collect()
     }
 
+    //returns all sessions with the given name
     pub unsafe fn get_sessions_by_name(&self, name: String) -> Vec<&Box<dyn Session>> {
         self.sessions.iter().filter(|i| i.getName() == name).collect()
+    }
+
+    //returns the first session with the given name
+    pub unsafe fn get_session_by_name(&self, name: String) -> Option<&Box<dyn Session>> {
+        self.sessions.iter().find(|i| i.getName() == name)
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,12 +156,7 @@ impl AudioController {
                     }
                 };
                 // Loop through all sessions and check if the session name already exists, if it does, change name to name + 1
-                let mut name = session_app_name;
-                let mut counter = 2;
-                while self.sessions.iter().any(|i| i.getName() == name) {
-                    name = format!("{}({})", name, counter);
-                    counter += 1;
-                }
+                let name = session_app_name;
     
                 let application_session = ApplicationSession::new(audio_control, name);
     
@@ -247,8 +242,8 @@ impl AudioController {
         self.sessions.iter().map(|i| i.getName()).collect()
     }
 
-    pub unsafe fn get_session_by_name(&self, name: String) -> Option<&Box<dyn Session>> {
-        self.sessions.iter().find(|i| i.getName() == name)
+    pub unsafe fn get_sessions_by_name(&self, name: String) -> Vec<&Box<dyn Session>> {
+        self.sessions.iter().filter(|i| i.getName() == name).collect()
     }
 
 }


### PR DESCRIPTION
This pull request to `src/lib.rs` includes changes to the `AudioController` implementation to simplify session name handling and modify session retrieval methods. The most important changes include removing the session name uniqueness enforcement and changing the session retrieval method to return multiple sessions.

Changes to session name handling:

* Removed the loop that enforced unique session names by appending a counter to the name if a session with the same name already existed. (`impl AudioController {` in `src/lib.rs`)

Changes to session retrieval methods:

* Modified the `get_session_by_name` method to `get_sessions_by_name` to return a vector of sessions with the specified name instead of a single session. (`impl AudioController {` in `src/lib.rs`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced session retrieval functionality to allow fetching multiple sessions by name.
  - Added a new method to retrieve all session names.

- **Bug Fixes**
  - Improved error handling for audio endpoint volume control.

- **Refactor**
  - Simplified logic for generating session names, removing unnecessary complexity.
  - Updated error handling to prevent potential panics when retrieving audio sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->